### PR TITLE
feat: user can view containers list/individual container detail view.

### DIFF
--- a/src/components/ShipItOut.jsx
+++ b/src/components/ShipItOut.jsx
@@ -12,6 +12,7 @@ import { BookingList } from "./booking/BookingList"
 import { BookingUpdate } from "./booking/BookingUpdate"
 import { ContainerList } from "./container/ContainerList"
 import { ContainerView } from "./container/ContainerView"
+
 import { ProductList } from "./product/ProductList"
 
 import styles from "./ShipItOut.module.css"
@@ -22,10 +23,11 @@ import { DataTableProvider } from "./table/DataTableProvider"
 
 export const ShipItOut = () => (
   <BrowserRouter>
+        <DataTableProvider>
     <main className={styles.shipItout}>
       <NavBar />
       <Switch>
-        <DataTableProvider>
+
           <Route exact path="/products/:id(\d+)" component={ProductList} />
           <Route exact path="/products" component={ProductList} />
 
@@ -36,7 +38,6 @@ export const ShipItOut = () => (
           <Route exact path="/bookings/:id(\d+)" component={BookingView} />
           <Route exact path="/bookings/create" component={BkgPage} />
           <Route exact path="/bookings" component={BookingList} />
-        </DataTableProvider>
 
         <Route exact path="/register" component={Register} />
         <Route exact path="/login" component={Login} />
@@ -45,6 +46,7 @@ export const ShipItOut = () => (
       </Switch>
       <Footer />
     </main>
+        </DataTableProvider>
   </BrowserRouter>
 );
 

--- a/src/components/booking/BookingView.jsx
+++ b/src/components/booking/BookingView.jsx
@@ -3,41 +3,8 @@ import { useLocation } from "react-router-dom"
 import { BookingView1 } from "./BookingView1"
 import { BookingView2 } from "./BookingView2"
 import { BookingView3 } from "./BookingView3"
-import { BookingView4 } from "./BookingView4"
 
 export const BookingView = () => {
-
-
-//  const [formValues, setFormValues] = useState({
-//   step: 1,
-//   service: 0,
-//   voyage: 0,
-//   carrier: 0,
-//   equipment_type: 0,
-//   cntr: 0,
-//   loading_port: 0,
-//   unloading_port: 0,
-//   status: 1,
-//   documents: false,
-//   dues: false,
-//   issues: false,
-//   pickup: new Date(),
-//   port_cut: new Date(),
-//   rail_cut: new Date(),
-//   address: "",
-//   bkg_notes: "",
-//   cntr_notes: "",
-//   cntrDamaged: false,
-//   inspection: false,
-//   overweight: false,
-//   commodity: "",
-//   weight: 0,
-//   fragile: false,
-//   hazardous: false,
-//   reefer: false,
-//   productDamaged: false
-//  })
-
 
 const [ formValues, setFormValues ] = useState([])
 const location = useLocation()
@@ -56,60 +23,8 @@ useEffect(() => {
         addStep['step'] = 1
         setFormValues(addStep)
       })
-  // .then(res => {
-  //   console.log(" in then ")
-  //   res = filterBookingViewData({...res})
-  //   setData(res)
-  //   console.log("new data")
-  //   console.table(res)
-  // })
 
 }, []) // useEffect
-
-//  useEffect(() => {
-      // fetch(`${process.env.REACT_APP_API}/${endpoint}`, {
-      //   headers: {
-      //     Authorization: `Token ${token}`
-      //   }
-      // })
-//       .then(res => res.json())
-//       .then(res => {
-
-//         setData(res)
-//         const colHeaders = Object.keys(res[0])
-
-//         const headers = colHeaders.map((header) => {
-//           return {
-//             field: `${header}`,
-//             headerName: `${header}`,
-//             description: `${header}`,
-//             width: 140
-//           }
-//         })
-//         setColumns(headers)
-//         setIsLoading(false)
-//       })
-//       .catch(err => {
-//         const header = 'Data Not Found'
-//         setColumns([
-//           {
-//             field: `${header}`,
-//             headerName: `${header}`,
-//             description: `${header}`,
-//             flex: 1
-//           }
-//         ])
-//         setData([
-//           {
-//             id: 0,
-//             header: header
-//           }
-//         ])
-//         setIsLoading(false)
-//       })
-
-//   }, [])
-
 
 
  const nextStep = () => {
@@ -152,18 +67,6 @@ useEffect(() => {
     />
    )
 
-  case 4:
-   return (
-    <BookingView4
-     nextStep={nextStep}
-     backStep={prevStep}
-     formValues={formValues}
-    />
-   )
-  case 5:
-   return (
-    <>Back to Booking Page</>
-   )
   default:
    return (
     <>Booking Loading . . </>

--- a/src/components/container/ContainerView.jsx
+++ b/src/components/container/ContainerView.jsx
@@ -1,127 +1,102 @@
-import React from "react"
+import React, { useState, useEffect } from "react"
+import { useLocation, useParams } from "react-router-dom"
+import { ContainerView1 } from "./ContainerView1"
+import { ContainerView2 } from "./ContainerView2"
+import { ContainerView3 } from "./ContainerView3"
 
-import { Link } from "react-router-dom"
-
-import styles from "./ContainerView.module.css"
 
 export const ContainerView = () => {
- const agentDetails = {
-  name: "bkg1",
-  company: "company1",
-  email: "bkgA@email.com",
-  phone: "000-000-0001"
+
+const [ isLoading, setIsLoading ] = useState(true)
+const [ formValues, setFormValues ] = useState([])
+const location = useLocation()
+const endpoint =  location.pathname.slice(1)
+const token = localStorage.getItem("user_token")
+const { id } = useParams()
+
+useEffect(() => {
+  console.log("rerendering")
+}, [ formValues])
+
+useEffect(() => {
+  setIsLoading(true)
+  return fetch(`${process.env.REACT_APP_API}/bookings`, {
+    headers: {
+      Authorization: `Token ${token}`
+    }
+  })
+  .then(res => res.json())
+  .then(res => {
+    console.table(res)
+    // console.log(Array.isArray(res))
+    res = res.filter(r => parseInt(r.id) === parseInt(id))[0]
+    // console.log(Array.isArray(res))
+    // console.log(id)
+    console.log("in then")
+    console.log(res)
+    const addStep = { ...res }
+    addStep['step'] = 2
+    // setFormValues(addStep)
+    // console.log(formValues)
+    // console.log("data is ============================")
+    // console.table(formValues)
+    // setIsLoading(false)
+    return addStep
+  }).then(res => {
+    console.log("res")
+    console.log(res)
+    setFormValues(res)
+    setIsLoading(false)
+  })
+
+}, []) // useEffect
+
+if(isLoading) return <>Loading .. </>
+
+ const nextStep = () => {
+  const { step } = formValues
+  setFormValues({ ...formValues, step: step + 1 })
  }
 
- const bookingDetails = {
-  service: "WC",
-  voyage: "voyage1",
-  carrier: "Trucker1",
-  container_type: "20ST",
-  container: "XYZ1234",
-  origin: "NYC, US",
-  destination: "Perth, AU",
-  status: "Pending",
-  damged: false,
-  inspection: true,
-  overweight: false,
-  pickup:  "06-25-2020 08:30",
-  portcut: "06-29-2020 12:00",
-  railcut: "",
-  address: "123 fake streeet",
-  notes: "Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iusto maxime accusamus saepe ducimus minus veritatis delectus inventore necessitatibus. Esse, doloremque."
+ const prevStep = () => {
+  const { step } = formValues
+  setFormValues({ ...formValues, step: step - 1 })
  }
- return (
 
-  <section className={styles.bookingInfo}>
-   <form className={styles.bookingInfo__form}>
-    <fieldset className={styles.leftSide}>
-     <legend className={styles.sideHeader}>Agent</legend>
-       <div>
-        <label for="contact">Contact:</label><br/>
-        <input type="text" name="contact" id="contact" placeholder={`${agentDetails.name}`} disabled/>
-       </div>
-       <div>
-        <label for="email">Email:</label><br/>
-        <input type="email" name="email" id="email" placeholder={`${agentDetails.email}`} disabled />
-       </div>
-       <div>
-        <label for="phone">Phone:</label><br/>
-        <input type="tel" name="phone" id="phone" placeholder={`${agentDetails.phone}`} disabled/>
-       </div>
-    </fieldset>
-    <fieldset className={styles.rightSide}>
-     <legend className={styles.sideHeader}>Booking</legend>
-       <div>
-        <label for="service">Service:</label><br/>
-        <input type="text" name="service" id="service" placeholder={`${bookingDetails.service}`} disabled/>
-       </div>
-       <div>
-        <label for="carrier">Carrier:</label><br/>
-        <input type="text" name="carrier" id="carrier" placeholder={`${bookingDetails.carrier}`} disabled />
-       </div>
-       <div>
-        <label for="container_type">Container Type:</label><br/>
-        <input type="text" name="container_type" id="container_type" placeholder={`${bookingDetails.container_type}`} disabled/>
-       </div>
-       <div>
-        <label for="container">Container:</label><br/>
-        <input type="text" name="container" id="container" placeholder={`${bookingDetails.container}`} disabled/>
-       </div>
-       <div>
-        <label for="origin">Origin:</label><br/>
-        <input type="text" name="origin" id="origin" placeholder={`${bookingDetails.origin}`} disabled/>
-       </div>
-       <div>
-        <label for="destination">Destination:</label><br/>
-        <input type="text" name="destination" id="destination" placeholder={`${bookingDetails.destination}`} disabled/>
-       </div>
-       <div>
-        <label for="status">Status:</label><br/>
-        <input type="text" name="status" id="status" placeholder={`${bookingDetails.status}`} disabled/>
-       </div>
 
-       <div className={styles.checkboxes}>
-        <div className={styles.checkbox__item}>
-         <input type="checkbox" name="damged" id="damged" placeholder={`${bookingDetails.damged}`} checked={bookingDetails.damged ? "checked" : ""} disabled/>
-         <label for="damged">damged Submitted</label>
-        </div>
-        <div className={styles.checkbox__item}>
-         <input type="checkbox" name="inspection" id="inspection" placeholder={`${bookingDetails.inspection}`} checked={bookingDetails.inspection ? "checked" : ""}  disabled/>
-         <label for="inspection">Money Owed</label>
-        </div>
-        <div className={styles.checkbox__item}>
-         <input type="checkbox" name="overweight" id="overweight" placeholder={`${bookingDetails.overweight}`} checked={bookingDetails.overweight ? "checked" : ""}  disabled/>
-         <label for="overweight">overweight</label>
-        </div>
-       </div>
-       <div className={styles.times}>
-         <div className={styles.field__item}>
-         <label for="address">Address</label><br/>
-         <input type="text" name="address" id="address" placeholder={`${bookingDetails.address}`} disabled /><br />
-        </div>
-        <div className={styles.field__item}>
-         <label for="pickup">Pickup</label><br/>
-         <input type="datetime-local" name="pickup" id="pickup" placeholder={`${bookingDetails.pickup}`} disabled/><br />
-        </div>
-        <div className={styles.field__item}>
-         <label for="portcut">Portcut</label><br/>
-         <input type="datetime-local" name="portcut" id="portcut" placeholder={`${bookingDetails.portcut}`} disabled/><br />
-        </div>
-        <div className={styles.field__item}>
-         <label for="railcut">Railcut</label><br/>
-         <input type="date" name="railcut" id="railcut" placeholder={`${bookingDetails.railcut}`} disabled/><br />
-        </div>
-        <div className={styles.field__item}>
-        <label for="notes">Notes</label><br/>
-        <textarea id="notes" name="notes" rows="4" cols="20" placeholder={`${bookingDetails.notes}`} disabled ><br />
-        </textarea>
-       </div>       
-       <Link className={styles.navLink} to='/containers' >
-          <button className={styles.navLinkBtn}>Back</button>
-        </Link>
-       </div>
-    </fieldset>
-   </form>
-  </section>
- )
+ switch (formValues.step) {
+  case 1:
+   return (
+    <ContainerView1
+     nextStep={nextStep}
+     formValues={formValues}
+    />
+   )
+
+  case 2:
+   return (
+
+    <ContainerView2
+     nextStep={nextStep}
+     prevStep={prevStep}
+     formValues={formValues}
+    />
+   )
+
+  case 3:
+   return (
+
+    <ContainerView3
+     nextStep={nextStep}
+     prevStep={prevStep}
+     formValues={formValues}
+    />
+   )
+
+  default:
+   return (
+    <>Booking Loading . . </>
+   )
+
+ } // swtich
 }

--- a/src/components/container/ContainerView1.jsx
+++ b/src/components/container/ContainerView1.jsx
@@ -1,0 +1,172 @@
+import React from "react"
+
+import { makeStyles } from '@material-ui/core/styles'
+import { Grid, TextField, FormControl, FormLabel, FormGroup, FormControlLabel, Checkbox, FormHelperText, Button } from "@material-ui/core"
+import { DateTimePicker } from "@material-ui/pickers"
+import TextareaAutosize from '@material-ui/core/TextareaAutosize'
+import { ThemeProvider } from "@material-ui/core/styles"
+
+
+export const ContainerView1 = ({ nextStep, formValues }) => {
+
+
+ const useStyles = makeStyles((theme) => ({
+  root: {
+   '& .MuiTextField-root': {
+    margin: theme.spacing(1),
+    width: 80,
+   },
+  },
+  formControl: {
+   margin: theme.spacing(1),
+   minWidth: 120,
+  },
+  selectEmpty: {
+   marginTop: theme.spacing(2),
+  },
+  button: {
+   margin: theme.spacing(1),
+  },
+ }));
+
+
+ const classes = useStyles();
+
+ const next = (e) => {
+  e.preventDefault()
+  nextStep()
+ }
+
+ return (
+  <ThemeProvider>
+
+   <fieldset style={{ margin: "0 auto", width: "60%"}}>
+    <h1 style={{ margin: "0 auto", textAlign: "center" }}>{formValues.step} View {formValues.booking}</h1>
+    <form className={classes.root} noValidate autoComplete="off" style={{ border: "black", width: "100%", margin: "0 auto" }}>
+     <Grid container spacing={4} style={{ width: "100%", margin: "0 auto " }}>
+      <Grid item xs={4} container direction="column">
+       <TextField id="name" name="name" label="Agent Name" defaultValue={formValues.full_name} disabled style={{ width: "50%" }} />
+       <TextField id="email" name="email" label="Agent Email" defaultValue={formValues.email} disabled style={{ width: "50%" }} />
+       <TextField id="phone" name="phone" label="Agent Phone" defaultValue={formValues.phone} disabled style={{ width: "50%" }} />
+       <div style={{width: "100%", marginTop: "100%", display: "flex", justifyContent: "space-between"}}>
+        <Button 
+         variant="contained" 
+         color="secondary" 
+         label="cabcek" 
+         href="/bookings"
+         className={classes.button}
+         >
+          Cancel
+        </Button>
+        <Button></Button>
+        <Button
+         variant="contained"
+         color="secondary"
+         label="continue"
+         className={classes.button}
+         onClick={next}
+        >
+         Next
+        </Button>
+
+       </div>
+
+      </Grid>
+
+      <Grid item xs={4}>
+        <TextField id="service" name="service" label="Service" defaultValue={formValues.service} disabled style={{ width: "50%" }} />
+        <TextField id="voyage" name="voyage" label="Voyage" defaultValue={formValues.voyage} disabled style={{ width: "50%" }} />
+        <TextField id="carrier" name="carrier" label="Carrier" defaultValue={formValues.carrier} disabled style={{ width: "50%" }} />
+        <TextField id="size" name="size" label="Container Type" defaultValue={formValues.size} disabled style={{ width: "50%" }} />
+        <TextField id="container" name="container" label="Container" defaultValue={formValues.container} disabled style={{ width: "50%" }} />
+        <TextField id="port" name="port" label="Loading Port" defaultValue={formValues.port} disabled style={{ width: "50%" }} />
+        <TextField id="destination" name="destination" label="Unloading Port" defaultValue={formValues.destination} disabled style={{ width: "50%" }} />
+        <TextField id="booking_status" name="booking_status" label="Booking Status" defaultValue={formValues.booking_status} disabled style={{ width: "50%" }} />
+
+      </Grid>
+
+      <Grid item xs={4}>
+       <FormControl component="fieldset" className={classes.formControl} disabled>
+        <FormLabel component="legend">Verify About Booking</FormLabel>
+        <FormGroup>
+
+         <FormControlLabel
+          id="document_submitted"
+          name="document_submitted"
+          label="Documents"
+          control={<Checkbox checked={formValues.document_submitted}  name="document_submitted" />}
+         />
+
+         <FormControlLabel
+          id="money_owed"
+          name="money_owed"
+          label="Dues"
+          control={<Checkbox checked={formValues.money_owed}  name="money_owed" />}
+         />
+
+         <FormControlLabel
+          id="issues"
+          name="issues"
+          label="Issues"
+          control={<Checkbox checked={formValues.issues}  name="issues" />}
+         />
+        </FormGroup>
+
+
+        <FormHelperText>Safety First</FormHelperText>
+       </FormControl>
+       <DateTimePicker
+        style={{ width: '100%' }}
+        value={formValues.pickup_appt}
+        
+        label="Pick Up"
+        showTodayButton
+        disabled
+       />
+
+       <DateTimePicker
+        style={{ width: '100%' }}
+        value={formValues.port_cut}
+
+        label="Port Cut"
+        showTodayButton
+        disabled
+       />
+
+       <DateTimePicker
+        style={{ width: '100%' }}
+        value={formValues.rail_cut}
+        disablePast
+
+        label="Rail Cut"
+        showTodayButton
+        disabled
+       />
+       <TextField
+        id="address"
+        name="address"
+        label="Pickup Address"
+        defaultValue={formValues.address}
+        style={{ width: "100%" }}
+        disabled
+        
+       />
+       <TextareaAutosize
+        id="bkg_notes"
+        name="bkg_notes"
+        aria-label="empty textarea"
+        placeholder="Booking Notes"
+        value={formValues.booking_notes}
+        style={{ width: "100%" }}
+        rowsMin={5}
+        disabled
+        
+       />
+      </Grid>
+     </Grid>
+    </form>
+   </fieldset >
+  </ThemeProvider>
+
+ )
+}

--- a/src/components/container/ContainerView2.jsx
+++ b/src/components/container/ContainerView2.jsx
@@ -1,0 +1,194 @@
+import React from "react"
+
+import { makeStyles } from '@material-ui/core/styles'
+import { Grid, TextField, FormControl, FormLabel, FormGroup, FormControlLabel, Checkbox, FormHelperText, Button } from "@material-ui/core"
+import { DateTimePicker } from "@material-ui/pickers"
+import TextareaAutosize from '@material-ui/core/TextareaAutosize'
+import { ThemeProvider } from "@material-ui/core/styles"
+import { useEffect } from "react"
+
+
+export const ContainerView2 = ({ nextStep, prevStep, formValues }) => {
+ console.log("form values are ContainerView2")
+ console.table(formValues)
+
+ console.log(formValues.container)
+
+ useEffect(() => {
+   console.log(" ")
+ }, [ nextStep])
+
+ const useStyles = makeStyles((theme) => ({
+  root: {
+   '& .MuiTextField-root': {
+    margin: theme.spacing(1),
+    width: 80,
+   },
+  },
+  formControl: {
+   margin: theme.spacing(1),
+   minWidth: 120,
+  },
+  selectEmpty: {
+   marginTop: theme.spacing(2),
+  },
+  button: {
+   margin: theme.spacing(1),
+  },
+ }));
+
+
+ const classes = useStyles();
+
+ const next = (e) => {
+  e.preventDefault()
+  nextStep()
+ }
+
+ const back = (e) => {
+    e.preventDefault()
+    prevStep()
+  }
+
+ return (
+  <ThemeProvider>
+
+   <fieldset style={{ margin: "0 auto", width: "60%" }} >
+    <h1 style={{ margin: "0 auto", textAlign: "center" }}>{formValues.step} View {formValues.container}</h1>
+    <form className={classes.root} noValidate autoComplete="off" style={{ border: "black", width: "100%", margin: "0 auto" }}>
+     <Grid container spacing={4} style={{ width: "100%", margin: "0 auto " }}>
+      <Grid item xs={4} container direction="column">
+       <TextField id="name" name="name" label="Agent Name" defaultValue={formValues.full_name} disabled style={{ width: "50%" }} />
+       <TextField id="email" name="email" label="Agent Email" defaultValue={formValues.email} disabled style={{ width: "50%" }} />
+       <TextField id="phone" name="phone" label="Agent Phone" defaultValue={formValues.phone} disabled style={{ width: "50%" }} />
+       <div style={{width: "100%", marginTop: "100%", display: "flex", justifyContent: "space-between"}}>
+        <Button 
+         variant="contained" 
+         color="secondary" 
+         label="cabcek" 
+         href="/bookings"
+         className={classes.button}
+        >
+          Cancel
+        </Button>
+        <Button
+         variant="contained"
+         color="secondary"
+         label="continue"
+         className={classes.button}
+         onClick={back}
+        >
+         Back
+        </Button>
+        <Button
+         variant="contained"
+         color="secondary"
+         label="continue"
+         className={classes.button}
+         onClick={next}
+        >
+         Next
+        </Button>
+
+       </div>
+
+      </Grid>
+
+      <Grid item xs={4}>
+        <TextField id="service" name="service" label="Service" defaultValue={formValues.service} disabled style={{ width: "50%" }} />
+        <TextField id="voyage" name="voyage" label="Voyage" defaultValue={formValues.voyage} disabled style={{ width: "50%" }} />
+        <TextField id="carrier" name="carrier" label="Carrier" defaultValue={formValues.carrier} disabled style={{ width: "50%" }} />
+        <TextField id="size" name="size" label="Container Type" defaultValue={formValues.size} disabled style={{ width: "50%" }} />
+        <TextField id="container" name="container" label="Container" defaultValue={formValues.container} disabled style={{ width: "50%" }} />
+        <TextField id="port" name="port" label="Loading Port" defaultValue={formValues.port} disabled style={{ width: "50%" }} />
+        <TextField id="destination" name="destination" label="Unloading Port" defaultValue={formValues.destination} disabled style={{ width: "50%" }} />
+        <TextField id="booking_status" name="booking_status" label="Booking Status" defaultValue={formValues.booking_status} disabled style={{ width: "50%" }} />
+
+      </Grid>
+      <Grid item xs={4}>
+       <FormControl component="fieldset" className={classes.formControl}>
+        <FormLabel component="legend">Verify About Container</FormLabel>
+        <FormGroup>
+
+         <FormControlLabel
+          id="container_damaged"
+          name="container_damaged"
+          label="Damaged"
+          control={<Checkbox checked={formValues.container_damaged}  name="container_damaged" />}
+          disabled
+         />
+
+         <FormControlLabel
+          id="needs_inspection"
+          name="needs_inspection"
+          label="Needs Inspection"
+          control={<Checkbox checked={formValues.needs_inspection}  name="needs_inspection" />}
+          disabled
+         />
+
+         <FormControlLabel
+          id="overweight"
+          name="overweight"
+          label="Overweight"
+          control={<Checkbox checked={formValues.overweight}  name="overweight" />}
+          disabled
+         />
+        </FormGroup>
+
+
+        <FormHelperText>Safety First</FormHelperText>
+       </FormControl>
+       <DateTimePicker
+        style={{ width: '100%' }}
+        value={formValues.pickup}
+
+        label="Pick Up"
+        showTodayButton
+        disabled
+       />
+
+       <DateTimePicker
+        style={{ width: '100%' }}
+        value={formValues.port_cut}
+
+        label="Port Cut"
+        showTodayButton
+        disabled
+       />
+
+       <DateTimePicker
+        style={{ width: '100%' }}
+        value={formValues.rail_cut}
+
+        label="Rail Cut"
+        showTodayButton
+        disabled
+       />
+       <TextField
+        id="address"
+        name="address"
+        label="Pickup Address"
+        defaultValue={formValues.address}
+        style={{ width: "100%" }}
+        
+        disabled
+       />
+       <TextareaAutosize
+        id="container_notes"
+        name="container_notes"
+        aria-label="empty textarea"
+        placeholder="Container Notes"
+        value={formValues.container_notes}
+        style={{ width: "100%" }}
+        rowsMin={5}
+        disabled
+        
+       />
+      </Grid>
+     </Grid>
+    </form>
+   </fieldset >
+  </ThemeProvider>
+
+ )
+}

--- a/src/components/container/ContainerView3.jsx
+++ b/src/components/container/ContainerView3.jsx
@@ -1,11 +1,17 @@
-import React from "react"
+import React, { useEffect } from "react"
 
 import { makeStyles } from '@material-ui/core/styles'
 import { Grid, TextField, FormControl, FormLabel, FormGroup, FormControlLabel, Checkbox, FormHelperText, Button } from "@material-ui/core"
 import { ThemeProvider } from "@material-ui/core/styles"
 
 
-export const BookingView3 = ({ nextStep, prevStep, formValues }) => {
+export const ContainerView3 = ({ prevStep, formValues }) => {
+
+console.log(formValues.container)
+
+ useEffect(() => {
+   console.log(" ")
+ }, [ prevStep])
 
 
  const useStyles = makeStyles((theme) => ({
@@ -36,12 +42,13 @@ export const BookingView3 = ({ nextStep, prevStep, formValues }) => {
     prevStep()
   }
 
+// if(!formValues.length) return <>Loading .. </>
 
  return (
   <ThemeProvider>
 
    <fieldset style={{ margin: "0 auto", width: "60%" }} >
-    <h1 style={{ margin: "0 auto", textAlign: "center" }}>View Product</h1>
+    <h1 style={{ margin: "0 auto", textAlign: "center" }}>{formValues.step} View Product</h1>
     <form className={classes.root} noValidate autoComplete="off" style={{ border: "black", width: "100%", margin: "0 auto" }}>
      <Grid container spacing={4} style={{ width: "100%", margin: "0 auto " }}>
       <Grid item xs={4} container direction="column">
@@ -75,8 +82,8 @@ export const BookingView3 = ({ nextStep, prevStep, formValues }) => {
       </Grid>
 
       <Grid item xs={4}>
-       <TextField id="commodity" name="commodity" label="Commodity" value={formValues.products[0].commodity}  disabled style={{ width: "50%" }} />
-       <TextField id="weight" name="weight" type="number" label="Weight (in lbs)" value={formValues.products[0].weight} disabled  style={{ width: "50%" }}  InputLabelProps={{
+       <TextField id="commodity" name="commodity" label="Commodity" value={formValues.products[0].commodity || ""}  disabled style={{ width: "50%" }} />
+       <TextField id="weight" name="weight" type="number" label="Weight (in lbs)" value={formValues.products[0].weight || 0} disabled  style={{ width: "50%" }}  InputLabelProps={{
             shrink: true,
             
           }} inputProps={{ min: 0}}/>

--- a/src/components/table/DataTable.jsx
+++ b/src/components/table/DataTable.jsx
@@ -137,7 +137,7 @@ export const DataTable = ({ endpoint, Icon }) => {
                   color="primary"
                   className={classes.button}
                   startIcon={<AddIcon />}
-                  href="/bookings/create"
+                  href="/${endpoint}/create"
                 >New</Button>
             }
             <Button


### PR DESCRIPTION
# Description

User can view container list page and individual container page (where they can scrol to the booking page or product page).

Closes #25 
Closes #26 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Testing Instructions

`git fetch --all`
`git checkout cr-routes-hitVariousEndpoints`
`python3 manage.py runserver --settings=shipItOutServer.settings.local `

## PostMan

## Browser

View list of containers at

`http://127.0.0.1:8000/containers`

View individual container at

`http://127.0.0.1:8000/containers/4`
# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works
